### PR TITLE
Psi4 Harness

### DIFF
--- a/qcdb/driver/endorsed_plugins.py
+++ b/qcdb/driver/endorsed_plugins.py
@@ -10,6 +10,7 @@ from .. import intf_gamess
 from qcengine.programs import register_program
 register_program(intf_cfour.QcdbCFOURHarness(name='QCDB-CFOUR'))
 register_program(intf_gamess.QcdbGAMESSHarness(name='QCDB-GAMESS'))
+register_program(intf_psi4.QcdbPsi4Harness(name='QCDB-Psi4'))
 
 if which('psi4') and which_import('psi4'):
     import psi4

--- a/qcdb/intf_psi4/__init__.py
+++ b/qcdb/intf_psi4/__init__.py
@@ -1,1 +1,1 @@
-from .runner import run_psi4
+from .runner import run_psi4, QcdbPsi4Harness


### PR DESCRIPTION
Psi4 calculations now run through `QCEngine`. The `ResultInput` and `JobConfig` fed into engine could still use a second look (missing things like memory) , but they're complete enough to pass nearly all of the tests.

The result of all Psi4 pytests are unchanged except for one: `test_fci-h2o-2.py::test_fci_rhf_psi4` fails due to an unrecognized qcvar, `DETCI AVG DVEC NORM`

