### PR TITLE
Nwctesting

### DIFF
--- a/qcdb/moptions/read_options2.py
+++ b/qcdb/moptions/read_options2.py
@@ -334,8 +334,7 @@ class RottenOption(object):
                 hist = user
             else:
                 raise OptionReconciliationError(
-                    'Conflicting option requirements btwn user ({}) and driver ({})'.
-                    format(user[0], driver[0]))
+                    f'Conflicting option requirements btwn user ({user[0]}) and driver ({driver[0]}) for {self.keyword}')
         
         #self.score = max_score
         return hist[0], max_score, hist

--- a/tests/nwchem_tests/test_dft_xc.py
+++ b/tests/nwchem_tests/test_dft_xc.py
@@ -5,12 +5,14 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
+@pytest.fixture
+def h2o():
+    h2o = qcdb.set_molecule('''
         O     0.00000000    0.000000000   0.11726921
         H     0.75698224    0.000000000   -0.46907685
         H     -0.75698224   0.000000000   -0.46907685
         ''')
-print(h2o)
+    return h2o
 
 
 def check_pbe0(return_value):
@@ -19,12 +21,12 @@ def check_pbe0(return_value):
 
 
 @using_nwchem
-def test_01_pbe0():
+def test_01_pbe0(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'pbe0',
     })
-    val = qcdb.energy('nwc-pbe0')
+    val = qcdb.energy('nwc-pbe0', molecule=h2o)
     check_pbe0(val)
 
 def check_b3lyp(return_value):
@@ -32,13 +34,13 @@ def check_b3lyp(return_value):
     assert compare_values(b3lyp, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b3lyp')
 
 @using_nwchem
-def test_02_b3lyp():
+def test_02_b3lyp(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'b3lyp'
     })
     print('Testing dft (b3lyp) energy...')
-    val = qcdb.energy('nwc-b3lyp')
+    val = qcdb.energy('nwc-b3lyp', molecule=h2o)
     check_b3lyp(val)
 
 def check_b1b95(return_value):
@@ -46,13 +48,13 @@ def check_b1b95(return_value):
     assert compare_values(b1b95, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b1b95')
 
 @using_nwchem
-def test_03_b1b95():
+def test_03_b1b95(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'b1b95',
     })
     print('Testing dft (b1b95) energy ...')
-    val = qcdb.energy('nwc-b1b95')
+    val = qcdb.energy('nwc-b1b95', molecule=h2o)
     check_b1b95(val)
 
 def check_b971(return_value):
@@ -60,13 +62,13 @@ def check_b971(return_value):
     assert compare_values(b971, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b971')
 
 @using_nwchem
-def test_04_b971():
+def test_04_b971(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'becke97-1',
     })
     print('Testing dft (b971) energy ...')
-    val = qcdb.energy('nwc-b97-1')
+    val = qcdb.energy('nwc-b97-1', molecule=h2o)
     check_b971(val)
 
 def check_b972(return_value):
@@ -74,13 +76,13 @@ def check_b972(return_value):
     assert compare_values(b972, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b972')
 
 @using_nwchem
-def test_05_b972():
+def test_05_b972(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'becke97-2',
     })
     print('Testing dft (b97-2) energy ...')
-    val = qcdb.energy('nwc-b97-2')
+    val = qcdb.energy('nwc-b97-2', molecule=h2o)
     check_b972(val)
 
 def check_b97gga1(return_value):
@@ -88,13 +90,13 @@ def check_b97gga1(return_value):
     assert compare_values(b97gga1, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b97gga1')
 
 @using_nwchem
-def test_06_b97gga1():
+def test_06_b97gga1(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'becke97gga1',
     })
     print('Testing dft (becke97gga1) energy ...')
-    val = qcdb.energy('nwc-b97-gga1')
+    val = qcdb.energy('nwc-b97-gga1', molecule=h2o)
     check_b97gga1(val)
 
 def check_bhandh(return_value):
@@ -102,13 +104,13 @@ def check_bhandh(return_value):
     assert compare_values(bhandh, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft bhandh')
 
 @using_nwchem
-def test_07_bhandh():
+def test_07_bhandh(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'beckehandh'
     })
     print('Testing dft (bhandh) energy ...')
-    val = qcdb.energy('nwc-bhandh')
+    val = qcdb.energy('nwc-bhandh', molecule=h2o)
     check_bhandh(val)
 
 def check_bop(return_value):
@@ -116,13 +118,13 @@ def check_bop(return_value):
     assert compare_values(bop, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft bop')
 
 @using_nwchem
-def test_08_bop():
+def test_08_bop(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc': 'bop'
     })
     print('Testing dft (bop) energy...')
-    val = qcdb.energy('nwc-bop')
+    val = qcdb.energy('nwc-bop', molecule=h2o)
     check_bop(val)
 
 def check_dldf(return_value):
@@ -130,13 +132,13 @@ def check_dldf(return_value):
     assert compare_values(dldf, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft dldf')
 
 @using_nwchem
-def test_09_dldf():
+def test_09_dldf(h2o):
     qcdb.set_options({
         'basis':  'cc-pvdz',
         'nwchem_dft__xc' : 'dldf',
     })
     print('Testing dft (dldf) energy...')
-    val = qcdb.energy('nwc-dldf')
+    val = qcdb.energy('nwc-dldf', molecule=h2o)
     check_dldf(val)
 
 def check_ft97(return_value):
@@ -144,12 +146,12 @@ def check_ft97(return_value):
     assert compare_values(ft97, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft ft97')
 
 @using_nwchem
-def test_10_ft97():
+def test_10_ft97(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc':  'ft97',
     })
-    val = qcdb.energy('nwc-ft97')
+    val = qcdb.energy('nwc-ft97', molecule=h2o)
     check_ft97(val)
 
 def check_hcth(return_value):
@@ -157,12 +159,12 @@ def check_hcth(return_value):
     assert compare_values(hcth, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcth')
 
 @using_nwchem
-def test_11_hcth():
+def test_11_hcth(h2o):
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'nwchem_dft__xc':  'hcth'
     })
-    val = qcdb.energy('nwc-hcth')
+    val = qcdb.energy('nwc-hcth', molecule=h2o)
     check_hcth(val)
 
 def check_hcth120(return_vaue):
@@ -170,7 +172,7 @@ def check_hcth120(return_vaue):
     assert compare_values(hcth120, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcth120')
 
 @using_nwchem
-def test_12_hcth120():
+def test_12_hcth120(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'hcth120'
@@ -181,12 +183,12 @@ def check_hcth407p(return_value):
     assert compare_values(hcth407p, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcth407p')
 
 @using_nwchem
-def test_13_hcth407p():
+def test_13_hcth407p(h2o):
     qcdb.set_options({
         'basis' :   'cc-pvdz',
         'nwchem_dft__xc' :  'hcth407p'
     })
-    val = qcdb.energy('nwc-hcth407p')
+    val = qcdb.energy('nwc-hcth407p', molecule=h2o)
     check_hcth407p(val)
 
 def check_hcthp14(return_value):
@@ -194,12 +196,12 @@ def check_hcthp14(return_value):
     assert compare_values(hcthp14, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcthp14')
 
 @using_nwchem
-def test_14_hcthp14():
+def test_14_hcthp14(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'hcthp14'
     })
-    val = qcdb.energy('nwc-hcthp14')
+    val = qcdb.energy('nwc-hcthp14', molecule=h2o)
     check_hcthp14(val)
 
 def check_m05(return_value):
@@ -207,12 +209,12 @@ def check_m05(return_value):
     assert compare_values(m05, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m05')
 
 @using_nwchem
-def test_15_m05():
+def test_15_m05(h2o):
     qcdb.set_options({
         'basis' :   'cc-pvdz',
         'nwchem_dft__xc' : 'm05',
     })
-    val = qcdb.energy('nwc-m05')
+    val = qcdb.energy('nwc-m05', molecule=h2o)
     check_m05(val)
 
 def check_m05_2x(return_value):
@@ -220,12 +222,12 @@ def check_m05_2x(return_value):
     assert compare_values(m05_2x, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m05-2x')
 
 @using_nwchem
-def test_16_m05_2x():
+def test_16_m05_2x(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'm05-2x'
     })
-    val = qcdb.energy('nwc-m05-2x')
+    val = qcdb.energy('nwc-m05-2x', molecule=h2o)
     check_m05_2x(val)
 
 def check_m06(return_value):
@@ -233,12 +235,12 @@ def check_m06(return_value):
     assert compare_values(m06, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m06')
 
 @using_nwchem
-def test_17_m06():
+def test_17_m06(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' :  'm06'
     })
-    val = qcdb.energy('nwc-m06')
+    val = qcdb.energy('nwc-m06', molecule=h2o)
     check_m06(val)
 
 def check_m06_2x(return_value):
@@ -246,12 +248,12 @@ def check_m06_2x(return_value):
     assert compare_values(m06_2x, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m06-2x')
 
 @using_nwchem
-def test_18_m06_2x():
+def test_18_m06_2x(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'm06-2x',
         })
-    val = qcdb.energy('nwc-m06-2x')
+    val = qcdb.energy('nwc-m06-2x', molecule=h2o)
     check_m06_2x(val)
 
 def check_m06_hf(return_value):
@@ -259,12 +261,12 @@ def check_m06_hf(return_value):
     assert compare_values(m06_hf, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m06-hf')
 
 @using_nwchem
-def test_19_m06_hf():
+def test_19_m06_hf(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'm06-hf'
     })
-    val = qcdb.energy('nwc-m06-hf')
+    val = qcdb.energy('nwc-m06-hf', molecule=h2o)
     check_m06_hf(val)
 
 def check_m08_hx(return_value):
@@ -272,12 +274,12 @@ def check_m08_hx(return_value):
     assert compare_values(m08_hx, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m08-hx')
 
 @using_nwchem
-def test_20_m08_hx():
+def test_20_m08_hx(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'm08-hx',
     })
-    val = qcdb.energy('nwc-m08-hx')
+    val = qcdb.energy('nwc-m08-hx', molecule=h2o)
     check_m08_hx(val)
 
 def check_m08_so(return_value):
@@ -285,12 +287,12 @@ def check_m08_so(return_value):
     assert compare_values(m08_so, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m08-so')
 
 @using_nwchem
-def test_21_m08_so():
+def test_21_m08_so(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'm08-so'
     })
-    val = qcdb.energy('nwc-m08-so')
+    val = qcdb.energy('nwc-m08-so', molecule=h2o)
     check_m08_so(val)
 
 def check_m11(return_value):
@@ -298,12 +300,12 @@ def check_m11(return_value):
     assert compare_values(m11, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m11')
 
 @using_nwchem
-def test_22_m11():
+def test_22_m11(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'm11'
     })
-    val = qcdb.energy('nwc-m11')
+    val = qcdb.energy('nwc-m11', molecule=h2o)
     check_m11(val)
 
 def check_m11_l(return_value):
@@ -311,12 +313,12 @@ def check_m11_l(return_value):
     assert compare_values(m11_l, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m11-l')
 
 @using_nwchem
-def test_23_m11_l():
+def test_23_m11_l(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'm11-l',
     })
-    val = qcdb.energy('nwc-m11-l')
+    val = qcdb.energy('nwc-m11-l', molecule=h2o)
     check_m11_l(val)
 
 def check_mpw1b95(return_value):
@@ -324,12 +326,12 @@ def check_mpw1b95(return_value):
     assert compare_values(mpw1b95, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft mpw1b95')
 
 @using_nwchem
-def test_24_mpw1b95():
+def test_24_mpw1b95(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'mpw1b95'
     })
-    val = qcdb.energy('nwc-mpw1b95')
+    val = qcdb.energy('nwc-mpw1b95', molecule=h2o)
     check_mpw1b95(val)
 
 def check_mpw1k(return_value):
@@ -337,12 +339,12 @@ def check_mpw1k(return_value):
     assert compare_values(mpw1k, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft mpw1k')
 
 @using_nwchem
-def test_25_mpw1k():
+def test_25_mpw1k(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'mpw1k'
     })
-    val = qcdb.energy('nwc-mpw1k')
+    val = qcdb.energy('nwc-mpw1k', molecule=h2o)
     check_mpw1k(val)
 
 def check_pw6b95(return_value):
@@ -350,12 +352,12 @@ def check_pw6b95(return_value):
     assert compare_values(pw6b95, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft pw6b95')
 
 @using_nwchem
-def test_26_pw6b95():
+def test_26_pw6b95(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'pw6b95',
     })
-    val = qcdb.energy('nwc-pw6b95')
+    val = qcdb.energy('nwc-pw6b95', molecule=h2o)
     check_pw6b95(val)
 
 def check_pwb6k(return_value):
@@ -363,12 +365,12 @@ def check_pwb6k(return_value):
     assert compare_values(pwb6k, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft pwb6k')
 
 @using_nwchem
-def test_27_pwb6k():
+def test_27_pwb6k(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'pwb6k'
     })
-    val = qcdb.energy('nwc-pwb6k')
+    val = qcdb.energy('nwc-pwb6k', molecule=h2o)
     check_pwb6k(val)
 
 def check_tpssh(return_value):
@@ -376,12 +378,12 @@ def check_tpssh(return_value):
     assert compare_values(tpssh, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft tpss')
 
 @using_nwchem
-def test_28_tpssh():
+def test_28_tpssh(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc' : 'xctpssh'
     })
-    val = qcdb.energy('nwc-tpssh')
+    val = qcdb.energy('nwc-tpssh', molecule=h2o)
     check_tpssh(val)
 
 def check_bhlyp(return_value):
@@ -389,12 +391,12 @@ def check_bhlyp(return_value):
     assert compare_values(bhlyp, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft bhlyp')
 
 @using_nwchem
-def test_29_bhlyp():
+def test_29_bhlyp(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'bhlyp'
     })
-    val = qcdb.energy('nwc-bhlyp')
+    val = qcdb.energy('nwc-bhlyp', molecule=h2o)
     check_bhlyp(val)
 
 def check_hcth407(return_value):
@@ -402,12 +404,12 @@ def check_hcth407(return_value):
     assert compare_values(hcth407, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcth407')
 
 @using_nwchem
-def test_30_hcth407():
+def test_30_hcth407(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'hcth407'
     })
-    val = qcdb.energy('nwc-hcth407')
+    val = qcdb.energy('nwc-hcth407', molecule=h2o)
     check_hcth407(val)
 
 def check_pbeop(return_value):
@@ -415,12 +417,12 @@ def check_pbeop(return_value):
     assert compare_values(pbeop, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft pbeop')
 
 @using_nwchem
-def test_31_pbeop():
+def test_31_pbeop(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'pbeop'
     })
-    val = qcdb.energy('nwc-pbeop')
+    val = qcdb.energy('nwc-pbeop', molecule=h2o)
     check_pbeop(val)
 
 def check_b97d(return_value):
@@ -428,12 +430,12 @@ def check_b97d(return_value):
     assert compare_values(b97d, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b97d')
 
 @using_nwchem
-def test_32_b97d():
+def test_32_b97d(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'becke97-d'
     })
-    val = qcdb.energy('nwc-b97-d')
+    val = qcdb.energy('nwc-b97-d', molecule=h2o)
     check_b97d(val)
 
 def check_cft97(return_value):
@@ -441,12 +443,12 @@ def check_cft97(return_value):
     assert compare_values(cft97, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft cft97')
 
 @using_nwchem
-def test_33_cft97():
+def test_33_cft97(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'cft97'
     })
-    val = qcdb.energy('nwc-cft97')
+    val = qcdb.energy('nwc-cft97', molecule=h2o)
     check_cft97(val)
 
 def check_acm(return_value):
@@ -454,12 +456,12 @@ def check_acm(return_value):
     assert compare_values(acm, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft acm')
 
 @using_nwchem
-def test_34_acm():
+def test_34_acm(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'acm'
     })
-    val = qcdb.energy('nwc-acm')
+    val = qcdb.energy('nwc-acm', molecule=h2o)
     check_acm(val)
 
 def check_optx(return_value):
@@ -467,12 +469,12 @@ def check_optx(return_value):
     assert compare_values(optx, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft optx')
 
 @using_nwchem
-def test_35_optx():
+def test_35_optx(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'optx'
     })
-    val = qcdb.energy('nwc-optx')
+    val = qcdb.energy('nwc-optx', molecule=h2o)
     check_optx(val)
 
 def check_b98(return_value):
@@ -480,12 +482,12 @@ def check_b98(return_value):
     assert compare_values(b98, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft b98')
 
 @using_nwchem
-def test_36_b98():
+def test_36_b98(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'becke98'
     })
-    val = qcdb.energy('nwc-b98')
+    val = qcdb.energy('nwc-b98', molecule=h2o)
     check_b98(val)
 
 def check_xtpss03(return_value):
@@ -493,12 +495,12 @@ def check_xtpss03(return_value):
     assert compare_values(xtpss03, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft xtpss03')
 
 @using_nwchem
-def test_37_xtpss03():
+def test_37_xtpss03(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'xtpss03'
     })
-    val = qcdb.energy('nwc-xtpss03')
+    val = qcdb.energy('nwc-xtpss03', molecule=h2o)
     check_xtpss03(val)
 
 def check_bb1k(return_value):
@@ -506,12 +508,12 @@ def check_bb1k(return_value):
     assert compare_values(bb1k, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft bb1k')
 
 @using_nwchem
-def test_38_bb1k():
+def test_38_bb1k(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'bb1k'
     })
-    val = qcdb.energy('nwc-bb1k')
+    val = qcdb.energy('nwc-bb1k', molecule=h2o)
     check_bb1k(val)
 
 def check_vs98(return_value):
@@ -519,12 +521,12 @@ def check_vs98(return_value):
     assert compare_values(vs98, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft vs98')
 
 @using_nwchem
-def test_39_vs98():
+def test_39_vs98(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'vs98'
     })
-    val = qcdb.energy('nwc-vs98')
+    val = qcdb.energy('nwc-vs98', molecule=h2o)
     check_vs98(val)
 
 def check_m06_l(return_value):
@@ -532,12 +534,12 @@ def check_m06_l(return_value):
     assert compare_values(m06_l, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft m06-l')
 
 @using_nwchem
-def test_40_m06_l():
+def test_40_m06_l(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'm06-l'
     })
-    val = qcdb.energy('nwc-m06-l')
+    val = qcdb.energy('nwc-m06-l', molecule=h2o)
     check_m06_l(val)
 
 def check_hcth147(return_value):
@@ -545,11 +547,11 @@ def check_hcth147(return_value):
     assert compare_values(hcth147, qcdb.get_variable('DFT TOTAL ENERGY'), 5, 'dft hcth147')
 
 @using_nwchem
-def test_41_hcth147():
+def test_41_hcth147(h2o):
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_dft__xc': 'hcth147'
     })
-    val = qcdb.energy('nwc-hcth147')
+    val = qcdb.energy('nwc-hcth147', molecule=h2o)
     check_hcth147(val)
 

--- a/tests/nwchem_tests/test_eom_ccsd_h2o.py
+++ b/tests/nwchem_tests/test_eom_ccsd_h2o.py
@@ -5,13 +5,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O      0.000000000000     0.000000000000    -0.123909374404
-        H      0.000000000000     1.429936611037     0.983265845431
-        H      0.000000000000    -1.429936611037     0.983265845431
-        ''')
-
-print(h2o)
 
 def check_eomccsd(return_value):
     ref     =       -75.633713836043
@@ -73,6 +66,12 @@ def check_eomccsd(return_value):
 
 @using_nwchem
 def test_1_eomccsd():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis'     :       '6-31g*',
         'memory'    :       '15000 mb',

--- a/tests/nwchem_tests/test_n2_ccsd_t_.py
+++ b/tests/nwchem_tests/test_n2_ccsd_t_.py
@@ -5,11 +5,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-n2 = qcdb.set_molecule('''
-        n 0 0 -0.5
-        n 0 0  0.5 ''')
-
-print(n2)
 
 def check_ccsd_t_(return_value, is5050):
     hf          =   -108.929838333552
@@ -54,6 +49,10 @@ def check_ccsd_t_(return_value, is5050):
 
 @using_nwchem
 def test_2_a5050_no():
+    n2 = qcdb.set_molecule('''
+        n 0 0 -0.5
+        n 0 0  0.5 ''')
+
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'nwchem_ccsd__thresh'    : 1.0e-8,

--- a/tests/nwchem_tests/test_opt-rhf-scf.py
+++ b/tests/nwchem_tests/test_opt-rhf-scf.py
@@ -5,13 +5,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
-
 
 def check_rhf(return_value):
     ref = -76.010496306999
@@ -22,6 +15,12 @@ def check_rhf(return_value):
 
 @using_nwchem
 def test_1_hf():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': '6-31g*',
         'memory': '400 mb',

--- a/tests/nwchem_tests/test_rhf-ccsdtq.py
+++ b/tests/nwchem_tests/test_rhf-ccsdtq.py
@@ -5,12 +5,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o= qcdb.set_molecule('''
-        O 0.000000000000    0.000000000000   -0.065638538099
-        H 0.000000000000   -0.757480611647    0.520865616174
-        H 0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
 
 def check_ccsdtq(return_value):
     ref         =       -76.010496307079
@@ -25,6 +19,12 @@ def check_ccsdtq(return_value):
 
 @using_nwchem
 def test_1_ccsdtq():
+    h2o= qcdb.set_molecule('''
+        O 0.000000000000    0.000000000000   -0.065638538099
+        H 0.000000000000   -0.757480611647    0.520865616174
+        H 0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': '6-31g*',
         'memory': '2000 mb',

--- a/tests/nwchem_tests/test_rhf_scf_grad.py
+++ b/tests/nwchem_tests/test_rhf_scf_grad.py
@@ -8,13 +8,6 @@ import qcdb
 import numpy as np
 import pprint
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
-
 
 def check_hf(return_value):
     ref = -76.026760737428
@@ -29,6 +22,12 @@ def check_hf(return_value):
     assert compare_arrays(grads, qcdb.get_variable('CURRENT GRADIENT'), 5, 'hf grad')
 @using_nwchem
 def test_1_hf():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',

--- a/tests/nwchem_tests/test_rohf_scf_nh2.py
+++ b/tests/nwchem_tests/test_rohf_scf_nh2.py
@@ -11,12 +11,6 @@ import qcdb
    #     H    0.79970017     0.00000000     0.47726896
     #    ''')
 
-nh2= qcdb.set_molecule('''
-        N
-        H 1 1.008
-        H 1 1.008 2 105.0''')
-print(nh2)
-
 
 def check_hf(return_value):
     ref = -55.562683879400
@@ -28,6 +22,11 @@ def check_hf(return_value):
 
 @using_nwchem
 def test_1_rohf():
+    nh2= qcdb.set_molecule('''
+        N
+        H 1 1.008
+        H 1 1.008 2 105.0''')
+
     qcdb.set_options({
         'basis': 'cc-pVDZ',
         'memory': '270 mb',

--- a/tests/nwchem_tests/test_sp-dft-ccsdt.py
+++ b/tests/nwchem_tests/test_sp-dft-ccsdt.py
@@ -6,14 +6,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-
-print(h2o)
-
 
 def check_dft(return_value, is_dft):
     if is_dft:
@@ -33,6 +25,12 @@ def check_dft(return_value, is_dft):
 
 @using_nwchem
 def test_1_dft():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'memory': '6000 mb',
         'basis': 'sto-3g',
@@ -51,6 +49,12 @@ def test_1_dft():
 
 @using_nwchem
 def test_2_scf():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'sto-3g',
         'memory': '6000 mb',

--- a/tests/nwchem_tests/test_sp-rhf-mp2-energy.py
+++ b/tests/nwchem_tests/test_sp-rhf-mp2-energy.py
@@ -5,13 +5,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
-
 
 def check_mp2(return_value, is5050):
     ref = -76.026760737428
@@ -34,6 +27,12 @@ def check_mp2(return_value, is5050):
 
 @using_nwchem
 def test_1_a5050_no():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz', 
         'memory': '400 mb', 
@@ -51,6 +50,12 @@ def test_1_a5050_no():
 
 @using_nwchem
 def test_2_a5050():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz', 
         'memory': '400 mb', 

--- a/tests/nwchem_tests/test_sp-rhf-scf.py
+++ b/tests/nwchem_tests/test_sp-rhf-scf.py
@@ -7,13 +7,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
-
 
 def check_hf(return_value):
     ref = -76.026760737428
@@ -23,6 +16,12 @@ def check_hf(return_value):
 
 @using_nwchem
 def test_1_hf():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',

--- a/tests/nwchem_tests/test_sp-uhf-mp2.py
+++ b/tests/nwchem_tests/test_sp-uhf-mp2.py
@@ -6,13 +6,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-nh2 = qcdb.set_molecule('''
-         N        0.08546       -0.00020       -0.05091
-         H       -0.25454       -0.62639        0.67895
-         H       -0.25454       -0.31918       -0.95813
-        ''')
-print(nh2)
-
 
 def check_uhf_mp2(return_value, is_5050):
     ref = -55.566057523877
@@ -38,6 +31,12 @@ def check_uhf_mp2(return_value, is_5050):
 
 @using_nwchem
 def test_1_mp2_5050no():
+    nh2 = qcdb.set_molecule('''
+         N        0.08546       -0.00020       -0.05091
+         H       -0.25454       -0.62639        0.67895
+         H       -0.25454       -0.31918       -0.95813
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '3000 mb',

--- a/tests/nwchem_tests/test_sp_mp2_grad.py
+++ b/tests/nwchem_tests/test_sp_mp2_grad.py
@@ -6,13 +6,6 @@ from ..addons import *
 import qcdb
 import numpy as np
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-print(h2o)
-
 
 def check_mp2(val, is_df, is5050):
     if is_df:
@@ -54,6 +47,12 @@ def check_mp2(val, is_df, is5050):
 
 @using_nwchem
 def test_1_mp2():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',
@@ -71,6 +70,12 @@ def test_1_mp2():
 
 @using_nwchem
 def test_2_hf():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',
@@ -103,6 +108,12 @@ def test_2_hf():
 
 @using_nwchem
 def test_4_mp2_array():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',

--- a/tests/nwchem_tests/test_sp_rhf_ccsd_t-2.py
+++ b/tests/nwchem_tests/test_sp_rhf_ccsd_t-2.py
@@ -7,14 +7,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-
-print(h2o)
-
 
 def check_ccsd_t_2(return_value):
         ref = -76.026760737428
@@ -50,6 +42,12 @@ def check_ccsd_t_2(return_value):
 
 @using_nwchem
 def test_1_a5050_no():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '600 mb',

--- a/tests/nwchem_tests/test_tce_ccd.py
+++ b/tests/nwchem_tests/test_tce_ccd.py
@@ -6,13 +6,6 @@ import qcdb
 from ..addons import *
 from ..utils import *
 
-h2o = qcdb.set_molecule('''
-        O                     0.000000000000     0.000000000000    -0.234154782060
-        H                    -0.000000000000     2.702188571625     1.858103156322
-        H                     0.000000000000    -2.702188571625     1.858103156322
-        ''')
-
-print(h2o)
 
 def tce_ccd(return_value):
 
@@ -25,7 +18,13 @@ def tce_ccd(return_value):
     assert compare_values(ccd_corl, qcdb.get_variable('CCD CORRELATION'), 5, 'ccsd corl')
 
 @using_nwchem
-def test_1_uccsd():
+def test_1_rccd():
+    h2o = qcdb.set_molecule('''
+        O                     0.000000000000     0.000000000000    -0.234154782060
+        H                    -0.000000000000     2.702188571625     1.858103156322
+        H                     0.000000000000    -2.702188571625     1.858103156322
+        ''')
+
     qcdb.set_options({
         'basis'     :   'sto-3g',
         'scf__e_convergence'   :   1e-10,

--- a/tests/nwchem_tests/test_tce_ci_h2o.py
+++ b/tests/nwchem_tests/test_tce_ci_h2o.py
@@ -5,13 +5,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O      0.000000000000     0.000000000000    -0.123909374404
-        H      0.000000000000     1.429936611037     0.983265845431
-        H      0.000000000000    -1.429936611037     0.983265845431
-        ''')
-
-print(h2o)
 
 def check_cisd(return_value):
     hf           =   -74.506112017320
@@ -24,6 +17,12 @@ def check_cisd(return_value):
 
 @using_nwchem
 def test_1_cisd():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'sto-3g',
         'qc_module': 'TCE',
@@ -44,6 +43,12 @@ def check_cisdt(return_value):
 
 @using_nwchem
 def test_2_cisdt():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'sto-3g',
         'qc_module': 'TCE',
@@ -65,6 +70,12 @@ def check_cisdtq(return_value):
 
 @using_nwchem
 def test_3_cisdtq():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'sto-3g',
         'qc_module': 'TCE',

--- a/tests/nwchem_tests/test_tce_lccd_lccsd_h2o.py
+++ b/tests/nwchem_tests/test_tce_lccd_lccsd_h2o.py
@@ -6,13 +6,6 @@ import qcdb
 from ..addons import *
 from ..utils import *
 
-h2o = qcdb.set_molecule('''
-    H    0.000000000000000   1.079252144093028   1.474611055780858
-    O    0.000000000000000   0.000000000000000   0.000000000000000
-    H    0.000000000000000   1.079252144093028  -1.47461105578085
-       units au ''')
-
-print(h2o)
 
 def check_lccd(return_value):
     hf      =   -74.962663062066
@@ -25,6 +18,12 @@ def check_lccd(return_value):
 
 @using_nwchem
 def test_1_lccd():
+    h2o = qcdb.set_molecule('''
+    H    0.000000000000000   1.079252144093028   1.474611055780858
+    O    0.000000000000000   0.000000000000000   0.000000000000000
+    H    0.000000000000000   1.079252144093028  -1.47461105578085
+       units au ''')
+
     qcdb.set_options({
         'basis' : 'sto-3g',
         'memory': '1500 mb',
@@ -50,6 +49,12 @@ def check_lccsd(return_value):
 
 @using_nwchem
 def test_2_lccsd():
+    h2o = qcdb.set_molecule('''
+    H    0.000000000000000   1.079252144093028   1.474611055780858
+    O    0.000000000000000   0.000000000000000   0.000000000000000
+    H    0.000000000000000   1.079252144093028  -1.47461105578085
+       units au ''')
+
     qcdb.set_options({
         'basis' : 'sto-3g',
         'memory': '1500 mb',

--- a/tests/nwchem_tests/test_tce_mpn_h2o.py
+++ b/tests/nwchem_tests/test_tce_mpn_h2o.py
@@ -5,13 +5,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O      0.000000000000     0.000000000000    -0.123909374404
-        H      0.000000000000     1.429936611037     0.983265845431
-        H      0.000000000000    -1.429936611037     0.983265845431
-        ''')
-
-print(h2o)
 
 def check_tce_mp2(return_value):
     hf          =   -75.645085110552
@@ -24,6 +17,12 @@ def check_tce_mp2(return_value):
 
 @using_nwchem
 def test_1_mp2():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'qc_module': 'TCE',
@@ -48,6 +47,12 @@ def check_tce_mp3(return_value):
 #Check all corls to corr similar to qcng
 @using_nwchem
 def test_2_mp3():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'qc_module': 'TCE',
@@ -76,6 +81,12 @@ def check_tce_mp4(return_value):
 
 @using_nwchem
 def test_3_mp4():
+    h2o = qcdb.set_molecule('''
+        O      0.000000000000     0.000000000000    -0.123909374404
+        H      0.000000000000     1.429936611037     0.983265845431
+        H      0.000000000000    -1.429936611037     0.983265845431
+        ''')
+
     qcdb.set_options({
         'basis' : 'cc-pvdz',
         'qc_module': 'TCE',

--- a/tests/nwchem_tests/test_tce_rhf_ccsd.py
+++ b/tests/nwchem_tests/test_tce_rhf_ccsd.py
@@ -5,14 +5,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-
-print(h2o)
-
 
 def check_ccsd_t_(return_value):
     ref = -76.026760733967
@@ -28,6 +20,12 @@ def check_ccsd_t_(return_value):
 
 @using_nwchem
 def test_1_ccsd_t_():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '600 mb',

--- a/tests/nwchem_tests/test_tce_sp_rhf-ccsd_t_.py
+++ b/tests/nwchem_tests/test_tce_sp_rhf-ccsd_t_.py
@@ -5,15 +5,6 @@ from ..utils import *
 from ..addons import *
 import qcdb
 
-h2o = qcdb.set_molecule('''
-        O     0.000000000000    0.000000000000   -0.065638538099
-        H     0.000000000000   -0.757480611647    0.520865616174
-        H     0.000000000000    0.757480611647    0.520865616174
-        ''')
-
-print(h2o)
-
-
 
 def check_ccsd_t_(return_value):
 
@@ -53,6 +44,12 @@ def check_ccsd_t_(return_value):
 
 @using_nwchem
 def test_1_ccsd_t_():
+    h2o = qcdb.set_molecule('''
+        O     0.000000000000    0.000000000000   -0.065638538099
+        H     0.000000000000   -0.757480611647    0.520865616174
+        H     0.000000000000    0.757480611647    0.520865616174
+        ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '600 mb',

--- a/tests/nwchem_tests/test_tce_uhf_uccsd.py
+++ b/tests/nwchem_tests/test_tce_uhf_uccsd.py
@@ -19,6 +19,7 @@ def tce_uccsd(return_value):
 @using_nwchem
 def test_1_uccsd():
     h2o = qcdb.set_molecule('''
+    1 2
         H
         O H 0.96
         H O 0.96 H 104.0
@@ -37,3 +38,20 @@ def test_1_uccsd():
 
     val = qcdb.energy('nwc-ccsd')
     tce_uccsd(val)
+
+
+@using_nwchem
+def test_mol_chg_error():
+    h2o = qcdb.set_molecule('''
+        H
+        O H 0.96
+        H O 0.96 H 104.0
+        ''')
+
+    qcdb.set_options({
+        'basis'     :   'sto-3g',
+        'nwchem_charge'    : 1,
+        })
+
+    with pytest.raises(qcdb.OptionReconciliationError):
+        qcdb.energy('nwc-ccsd')

--- a/tests/nwchem_tests/test_tce_uhf_uccsd.py
+++ b/tests/nwchem_tests/test_tce_uhf_uccsd.py
@@ -6,14 +6,6 @@ import qcdb
 from ..addons import *
 from ..utils import *
 
-h2o = qcdb.set_molecule('''
-        H
-        O H 0.96
-        H O 0.96 H 104.0
-        ''')
-
-print(h2o)
-
 def tce_uccsd(return_value):
 
     hf  =   -74.656470840577
@@ -26,6 +18,12 @@ def tce_uccsd(return_value):
 
 @using_nwchem
 def test_1_uccsd():
+    h2o = qcdb.set_molecule('''
+        H
+        O H 0.96
+        H O 0.96 H 104.0
+        ''')
+
     qcdb.set_options({
         'basis'     :   'sto-3g',
         'scf__e_convergence'   :   1e-10,

--- a/tests/nwchem_tests/test_tddft_n2+.py
+++ b/tests/nwchem_tests/test_tddft_n2+.py
@@ -6,11 +6,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-n2_plus = qcdb.set_molecule('''
-        N 0.0 0.0 -0.54885
-        N 0.0 0.0  0.54885
-        ''')
-print(n2_plus)
 
 def check_tddft(return_value):
     if is_df:
@@ -64,6 +59,11 @@ def check_tddft(return_value):
 
 @using_nwchem
 def test_1_dft():
+    n2_plus = qcdb.set_molecule('''
+        N 0.0 0.0 -0.54885
+        N 0.0 0.0  0.54885
+        ''')
+
     qcdb.set_options({
         'basis': '6-31g**',
         'memory' : '3000 mb',

--- a/tests/nwchem_tests/test_uhf_scf.py
+++ b/tests/nwchem_tests/test_uhf_scf.py
@@ -5,13 +5,6 @@ from ..addons import *
 from ..utils import *
 import qcdb
 
-nh2 = qcdb.set_molecule('''
-           N        0.08546       -0.00020       -0.05091
-           H       -0.25454       -0.62639        0.67895
-           H       -0.25454       -0.31918       -0.95813
-           ''')
-print(nh2)
-
 
 def check_uhf_hf(return_value):
     ref = -55.566057523877
@@ -23,6 +16,12 @@ def check_uhf_hf(return_value):
 
 @using_nwchem
 def test_1_hf():
+    nh2 = qcdb.set_molecule('''
+           N        0.08546       -0.00020       -0.05091
+           H       -0.25454       -0.62639        0.67895
+           H       -0.25454       -0.31918       -0.95813
+           ''')
+
     qcdb.set_options({
         'basis': 'cc-pvdz',
         'memory': '400 mb',


### PR DESCRIPTION
This will let you run `pytest tests/` or `pytest -n4 tests/` and have most of the nwchem tests pass, no matter what order they were run in. @vivacebelles, note that the key thing is to not rely on variables defined outside the test fn. Or if you need to to avoid repetition (like in the dft) make it a pytest "fixture". You were probably emulating test files from before I fixed the main part of the test suite.

On the "conflicting values btwn user and driver", that has to do with charge being contradictory btwn the molecule and the options. setting only the molecule will be fine.