### PR TITLE
adapt qcdb runners to work with qcengine migrations

### DIFF
--- a/qcdb/intf_gamess/molbasopt.py
+++ b/qcdb/intf_gamess/molbasopt.py
@@ -1,6 +1,4 @@
 import uuid
-import textwrap
-import collections
 
 import qcelemental as qcel
 
@@ -57,44 +55,3 @@ def muster_and_format_molecule_and_basis_for_gamess(molrec, ropts, qbs, verbose=
     ropts.require('GAMESS', 'contrl__ispher', {True: 1, False: -1}[native_puream], **kwgs)
 
     return '\n'.join(uniq_atombas_lines)
-
-
-def format_option_for_gamess(opt, val, lop_off=True):
-    """Reformat `val` for option `opt` from python into GAMESS-speak."""
-
-    text = ''
-
-    # Transform booleans into Fortran booleans
-    if str(val) == 'True':
-        text += '.true.'
-    elif str(val) == 'False':
-        text += '.false.'
-
-    # No Transform
-    else:
-        text += str(val).lower()
-
-    if lop_off:
-        return opt[7:].lower(), text
-    else:
-        return opt.lower(), text
-
-
-def format_options_for_gamess(options):
-    """From GAMESS-directed, non-default options dictionary `options`, write a GAMESS deck."""
-
-    grouped_options = collections.defaultdict(dict)
-    for group_key, val in options.items():
-        group, key = group_key.split('__')
-        grouped_options[group][key] = val
-
-    grouped_lines = {}
-    for group, opts in sorted(grouped_options.items()):
-        line = []
-        line.append(f'${group.lower()}')
-        for key, val in grouped_options[group].items():
-            line.append('='.join(format_option_for_gamess(key, val, lop_off=False)))
-        line.append('$end\n')
-        grouped_lines[group] = textwrap.fill(' '.join(line), initial_indent=' ', subsequent_indent='  ')
-
-    return '\n'.join(grouped_lines.values()) + '\n'

--- a/qcdb/intf_gamess/runner.py
+++ b/qcdb/intf_gamess/runner.py
@@ -14,6 +14,7 @@ import qcengine as qcng
 from qcengine.exceptions import InputError
 from qcengine.programs.util import PreservingDict
 from qcengine.programs.gamess import GAMESSHarness
+from qcengine.programs.gamess.keywords import format_keywords
 
 from .. import __version__
 #from .. import moptions
@@ -25,7 +26,7 @@ from ..libmintsbasisset import BasisSet
 from ..util import provenance_stamp
 from ..molecule import Molecule
 from ..pdict import PreservingDict
-from .molbasopt import muster_and_format_molecule_and_basis_for_gamess, format_options_for_gamess
+from .molbasopt import muster_and_format_molecule_and_basis_for_gamess
 from .harvester import muster_modelchem, muster_inherited_options
 
 
@@ -223,11 +224,10 @@ class QcdbGAMESSHarness(GAMESSHarness):
         # Handle conversion of psi4 keyword structure into cfour format
         skma_options = {key: ropt.value for key, ropt in sorted(ropts.scroll['GAMESS'].items()) if ropt.disputed()}
 
-        #optcmd = format_keywords(skma_options)
-        optcmd = format_options_for_gamess(skma_options)
+        optcmd = format_keywords(skma_options)
 
         gamessrec['infiles']['gamess.inp'] = optcmd + molbascmd
-        gamessrec['commands'] = [which("rungms"), "gamess"]
+        gamessrec['command'] = [which("rungms"), "gamess"]
 
         return gamessrec
 

--- a/qcdb/intf_nwchem/molbasopt.py
+++ b/qcdb/intf_nwchem/molbasopt.py
@@ -9,17 +9,13 @@ import qcelemental as qcel
 from ..driver import pe
 
 
-def muster_and_format_molecule_for_nwchem(molrec, ropts, verbose=1):
-    accession = sys._getframe().f_code.co_name + '_' + str(uuid.uuid4())
-    kwgs = {'accession': accession, 'verbose': verbose}
+def format_molecule(molrec, ropts, verbose: int=1):
+    kwgs = {'accession': uuid.uuid4(), 'verbose': verbose}
 
-    units = 'Bohr'
-    molcmd = qcel.molparse.to_string(molrec, dtype='nwchem', units=units)
+    molcmd, moldata = qcel.molparse.to_string(molrec, dtype='nwchem', units='Bohr', return_data=True)
 
-    ropts.require('NWCHEM', 'charge', int(molrec['molecular_charge']), **kwgs)
-    if molrec['molecular_multiplicity'] != 1:
-        ropts.require('NWCHEM', 'scf__nopen', molrec['molecular_multiplicity'] - 1, **kwgs)
-        ropts.require('NWCHEM', 'dft__mult', molrec['molecular_multiplicity'], **kwgs)
+    for key, val in moldata['keywords'].items():
+        ropts.require('NWCHEM', key, val, **kwgs)
 
     return molcmd
 
@@ -144,127 +140,6 @@ def local_prepare_options_for_modules(changedOnly=False, commandsInsteadDict=Fal
     return query_options_defaults_from_psi(changedOnly=changedOnly)
 
 
-def fulllocal_prepare_options_for_modules(changedOnly=False, commandsInsteadDict=False):
-    """Function to return a string of commands to replicate the
-    current state of user-modified options. Used to capture C++
-    options information for distributed (sow/reap) input files.
-
-    .. caution:: Some features are not yet implemented. Buy a developer a coffee.
-
-       - Need some option to get either all or changed
-
-       - Need some option to either get dict or set string or psimod command list
-
-       - command return doesn't revoke has_changed setting for unchanged with changedOnly=False
-
-    """
-    import collections
-
-    modules = [
-        # PSI4 Modules
-        "ADC",
-        "CCENERGY",
-        "CCEOM",
-        "CCDENSITY",
-        "CCLAMBDA",
-        "CCHBAR",
-        "CCRESPONSE",
-        "CCSORT",
-        "CCTRIPLES",
-        "CLAG",
-        "CPHF",
-        "CIS",
-        "DCFT",
-        "DETCI",
-        "DFMP2",
-        "DFTSAPT",
-        "FINDIF",
-        "FNOCC",
-        "LMP2",
-        "MCSCF",
-        "MINTS",
-        "MRCC",
-        "OCC",
-        "OPTKING",
-        "PSIMRCC",
-        "RESPONSE",
-        "SAPT",
-        "SCF",
-        "STABILITY",
-        "THERMO",
-        "TRANSQT",
-        "TRANSQT2",
-        # External Modules
-        "CFOUR",
-    ]
-
-    options = collections.defaultdict(dict)
-    commands = ''
-    for opt in core.get_global_option_list():
-        if core.has_global_option_changed(opt) or not changedOnly:
-            if opt in ['DFT_CUSTOM_FUNCTIONAL', 'EXTERN']:  # Feb 2017 hack
-                continue
-            val = core.get_global_option(opt)
-            options['GLOBALS'][opt] = {'value': val, 'has_changed': core.has_global_option_changed(opt)}
-            if isinstance(val, str):
-                commands += """core.set_global_option('%s', '%s')\n""" % (opt, val)
-            else:
-                commands += """core.set_global_option('%s', %s)\n""" % (opt, val)
-            #if changedOnly:
-            #    print('Appending module %s option %s value %s has_changed %s.' % \
-            #        ('GLOBALS', opt, core.get_global_option(opt), core.has_global_option_changed(opt)))
-        for module in modules:
-            if core.option_exists_in_module(module, opt):
-                hoc = core.has_option_changed(module, opt)
-                if hoc or not changedOnly:
-                    val = core.get_option(module, opt)
-                    options[module][opt] = {'value': val, 'has_changed': hoc}
-                    if isinstance(val, str):
-                        commands += """core.set_local_option('%s', '%s', '%s')\n""" % (module, opt, val)
-                    else:
-                        commands += """core.set_local_option('%s', '%s', %s)\n""" % (module, opt, val)
-                    #if changedOnly:
-                    #    print('Appending module %s option %s value %s has_changed %s.' % \
-                    #        (module, opt, core.get_option(module, opt), hoc))
-
-    if commandsInsteadDict:
-        return commands
-    else:
-        return options
-
-
-def format_options_for_nwchem(options):
-    """From NWCHEM-directed, non-default options dictionary `options`, write a NWCHEM deck."""
-
-    grouped_options = collections.defaultdict(dict)
-    for group_key, val in options.items():
-        nesting = group_key.split('__')
-        if len(nesting) == 1:
-            group, key = 'aaaglobal', nesting[0]
-        elif len(nesting) == 2:
-            group, key = nesting
-        else:
-            print(nesting)
-            raise ValueError('Nesting!')
-#        group, key = group_key.split('__')
-        grouped_options[group][key] = val
-
-    grouped_lines = {}
-    for group, opts in sorted(grouped_options.items()):
-        line = []
-#        line.append(f'${group.lower()}')
-        for key, val in grouped_options[group].items():
-            line.append(' '.join(format_option_for_nwchem(key, val, lop_off=False)))
-#        line.append('end\n')
-        if group == 'aaaglobal':
-            grouped_lines[group] = '\n'.join(line) + '\n'
-        else:
-            grouped_lines[group] = f'{group.lower()}\n  ' + '\n  '.join(line) + '\nend\n'
-#        grouped_lines[group] = textwrap.fill(' '.join(line), initial_indent=' ', subsequent_indent='  ')
-
-    return '\n'.join(grouped_lines.values()) + '\n'
-
-
 def prepare_options_for_nwchem(options):
     """Function to take the full snapshot of the liboptions object
     encoded in dictionary *options*, find the options directable toward
@@ -377,103 +252,5 @@ def prepare_options_for_nwchem(options):
     return text
 
 
-def prepare_options_for_task_nwchem(options):
-    """Function to take the full snapshot of the liboptions object
-   encoded in dictionary *options*, find the options directable toward
-   NWChem (options['NWCHEM']['NWCHEM_TASK_**']) that aren't default, then write
-   a NWCHEM deck with those options. If TCE is set ON, this funcion also write 
-   appropriate NWCHEM_TCE_MODULE.  
-
-    """
-    task_value = ''
-    text = ''
-
-    if options['NWCHEM']['NWCHEM_TCE']['value'] == 'ON':
-        for opt, val in options['NWCHEM'].items():
-            if opt.startswith('NWCHEM_TASK'):
-                if val['has_changed']:
-                    if opt.startswith('NWCHEM_TASK_CCSD'):  #task ccsd, ccsd(t) -> task tce
-                        text += """tce; %s ; end\n""" % (opt[12:].lower())  # NWCHEM_TCE_MODULE =ccsd or ccsd(t)
-                        text += """task tce %s \n""" % (val['value'])
-            else:
-                pass
-    else:
-        for opt, val in options['NWCHEM'].items():
-            if opt.startswith('NWCHEM_TASK'):
-                if val['has_changed']:
-                    text += """task %s %s \n""" % (opt[12:].lower(), val['value'])
-            else:
-                pass
-
-    if text:
-        text = text[:-1] + '\n'
-
-    return text
-
-
-def format_option_for_nwchem(opt, val, lop_off=True):
-    """Function to reformat value *val* for option *opt* from python
-    into nwchem-speak. 
-        
-    """
-    text = ''
-    spaces = ' '
-
-    # Transform string booleans into " "
-    if val is True:
-        #text += spaces + opt
-        return opt.lower(), ''
-    elif val is False:
-        return '', ''
-    #if str(val) == 'TRUE':
-    #    text += '%s' % (spaces)
-    #elif str(val) == 'FALSE':
-    #    pass
-
-    # complete hack
-    if opt.upper() == 'MEMORY':
-        return opt.lower(), f'{val} byte'
-
-
-    elif isinstance(val, list):
-        for n in range(len(val)):
-            text += str(val[n])
-            if n < (len(val) - 1):
-                text += '%s' % (spaces)
-
-    else:
-        text += str(val)
-
-    if lop_off:
-        return opt[7:].lower(), text
-    else:
-        return opt.lower(), text
-
-
-def format_option_for_theory_block_nwchem(opt, val):
-    """Function to reformat value *val* for option *opt* BLOCK from python
-    into nwchem-speak. 
-        
-    """
-    text = ''
-    spaces = '  '
-
-    # Transform string booleans into " "
-    if str(val) == 'TRUE':
-        text += '%s' % (spaces)
-    elif str(val) == 'FALSE':
-        pass
-
-    elif isinstance(val, list):
-        for n in range(len(val)):
-            text += str(val[n])
-            if n < (len(val) - 1):
-                text += '%s' % (spaces)
-
-    elif str(val) == 'RODFT':
-        text += str(val) + '\ncgmin'
-
-    else:
-        text += str(val)
-
-    return opt.lower(), text
+#    elif str(val) == 'RODFT':
+#        text += str(val) + '\ncgmin'

--- a/qcdb/intf_nwchem/runner.py
+++ b/qcdb/intf_nwchem/runner.py
@@ -13,6 +13,7 @@ import qcengine as qcng
 from qcengine.exceptions import InputError
 from qcengine.programs.util import PreservingDict
 from qcengine.programs.nwchem import NWChemHarness
+from qcengine.programs.nwchem.keywords import format_keywords
 
 from .. import __version__
 from .. import moptions
@@ -26,7 +27,7 @@ from ..util import print_jobrec, provenance_stamp
 from . import harvester
 from .worker import nwchem_subprocess
 #from .molbas import * #format_molecule_for_nwchem, format_basis_for_nwchem, format_basis_for_nwchem_puream, local_prepare_options_for_modules
-from .molbasopt import muster_and_format_molecule_for_nwchem, muster_and_format_basis_for_nwchem, format_options_for_nwchem
+from .molbasopt import format_molecule, muster_and_format_basis_for_nwchem
 from .harvester import muster_inherited_options, format_modelchem_for_nwchem
 from ..moptions.options import reconcile_options
 
@@ -110,7 +111,7 @@ class QcdbNWChemHarness(NWChemHarness):
         molrecc1['fix_symmetry'] = 'c1'  # write _all_ atoms to input
         ropts = input_model.extras['qcdb:options']
 
-        molcmd = muster_and_format_molecule_for_nwchem(molrec, ropts, verbose=1)
+        molcmd = format_molecule(molrec, ropts, verbose=1)
 
     # Handle memory
     # I don't think memory belongs in jobrec. it goes in pkgrec (for pbs) and possibly duplicated in options (for prog)
@@ -154,7 +155,7 @@ class QcdbNWChemHarness(NWChemHarness):
 #OLD    optcmd = moptions.prepare_options_for_nwchem(jobrec['options'])
 #    resolved_options = {k: v.value for k, v in jobrec['options'].scroll['NWCHEM'].items() if v.disputed()}
         skma_options = {key: ropt.value for key, ropt in sorted(ropts.scroll['NWCHEM'].items()) if ropt.disputed()}
-        optcmd = format_options_for_nwchem(skma_options)
+        optcmd = format_keywords(skma_options)
 
     # Handle text to be passed untouched to cfour
 #    litcmd = core.get_global_option('LITERAL_CFOUR')

--- a/tests/test_lateral_ccsd_ene.py
+++ b/tests/test_lateral_ccsd_ene.py
@@ -33,99 +33,124 @@ R=1.008
 A=105.0
 """
 
-@pytest.mark.parametrize('mtd,opts', [
-    pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
-    pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p'}, marks=using_cfour),
-    pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p'}, marks=using_nwchem),
-    pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'qc_module': 'tce'}, marks=using_nwchem),
-    pytest.param('p4-ccsd', {'basis': 'cfour-qz2p'}, marks=using_psi4),
-    pytest.param('gms-ccsd', {'basis': 'cfour-qz2p', 'gamess_ccinp__ncore': 0}, marks=using_gamess),
+@pytest.mark.parametrize('basis', [
+    'cfour-qz2p',
+    'aug-cc-pvdz',
 ])
-def test_sp_ccsd_rhf_full(mtd, opts, h2o):
+@pytest.mark.parametrize('method,keywords', [
+    pytest.param('c4-ccsd', {'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
+    pytest.param('c4-ccsd', {}, marks=using_cfour),
+    pytest.param('nwc-ccsd', {}, marks=using_nwchem),
+    pytest.param('nwc-ccsd', {'qc_module': 'tce'}, marks=using_nwchem),
+    pytest.param('p4-ccsd', {}, marks=using_psi4),
+    pytest.param('gms-ccsd', {'gamess_ccinp__ncore': 0}, marks=using_gamess),
+])
+def test_sp_ccsd_rhf_full(method, basis, keywords, h2o):
     """cfour/sp-rhf-ccsd/input.dat
     #! single point CCSD/qz2p on water
 
     """
     h2o = qcdb.set_molecule(h2o)
-    qcdb.set_options(opts)
+    keywords['basis'] = basis
+    qcdb.set_options(keywords)
 
-    e, jrec = qcdb.energy(mtd, return_wfn=True, molecule=h2o)
+    e, jrec = qcdb.energy(method, return_wfn=True, molecule=h2o)
 
-    scftot = -76.062748460117
-    mp2tot = -76.332940127333
-    ccsdcorl = -0.275705491773
-    ccsdtot = -76.338453951890
+    if basis == 'cfour-qz2p':
+        scftot = -76.062748460117
+        mp2tot = -76.332940127333
+        ccsdcorl = -0.275705491773
+        ccsdtot = -76.338453951890
+    elif basis == 'aug-cc-pvdz':
+        scftot = -76.0413815332
+        mp2tot = -76.2632792578
+        mp2corl = -0.2218977246
+        ccsdcorl = -0.2294105794
+        ccsdtot = -76.2707921127
 
     atol = 1.e-6
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + ' SCF', atol=atol)
-    if not (mtd == 'nwc-ccsd' and opts.get('qc_module', 'nein').lower() == 'tce'):
+    if not (method == 'nwc-ccsd' and keywords.get('qc_module', 'nein').lower() == 'tce'):
         assert compare_values(mp2tot, qcdb.variable('mp2 total energy'), tnm() + ' MP2', atol=atol)
     assert compare_values(ccsdcorl, qcdb.variable('ccsd correlation energy'), tnm() + ' CCSD corl', atol=atol)
     assert compare_values(ccsdtot, qcdb.variable('ccsd total energy'), tnm() + ' CCSD', atol=atol)
+    #assert 0
 
 
-@pytest.mark.parametrize('mtd,opts', [
-    pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_dropmo': [1], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
-    pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p', 'cfour_dropmo': 1}, marks=using_cfour),
-    pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_ccsd__freeze': 1}, marks=using_nwchem),
-    pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'qc_module': 'tce', 'nwchem_tce__freeze': 1}, marks=using_nwchem),
-    pytest.param('p4-ccsd', {'basis': 'cfour-qz2p', 'psi4_freeze_core': True}, marks=using_psi4),
-    pytest.param('gms-ccsd', {'basis': 'cfour-qz2p'}, marks=using_gamess),
+@pytest.mark.parametrize('basis', [
+    'cfour-qz2p',
+    'aug-cc-pvdz',
 ])
-def test_sp_ccsd_rhf_fc(mtd, opts, h2o):
+@pytest.mark.parametrize('method,keywords', [
+    pytest.param('c4-ccsd', {'cfour_dropmo': [1], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
+    pytest.param('c4-ccsd', {'cfour_dropmo': 1}, marks=using_cfour),
+    pytest.param('nwc-ccsd', {'nwchem_ccsd__freeze': 1}, marks=using_nwchem),
+    pytest.param('nwc-ccsd', {'qc_module': 'tce', 'nwchem_tce__freeze': 1}, marks=using_nwchem),
+    pytest.param('p4-ccsd', {'psi4_freeze_core': True}, marks=using_psi4),
+    pytest.param('gms-ccsd', {}, marks=using_gamess),
+])
+def test_sp_ccsd_rhf_fc(method, keywords, basis, h2o):
     """cfour/sp-rhf-ccsd/input.dat
     #! single point CCSD/qz2p on water
 
     """
     h2o = qcdb.set_molecule(h2o)
-    qcdb.set_options(opts)
+    keywords['basis'] = basis
+    qcdb.set_options(keywords)
 
-    e, jrec = qcdb.energy(mtd, return_wfn=True, molecule=h2o)
+    e, jrec = qcdb.energy(method, return_wfn=True, molecule=h2o)
 
-    scftot = -76.062748460117
-    mp2corl = -0.245151837406
-    mp2tot = -76.307900312177
-    ccsdcorl = -0.250330548844
-    ccsdtot = -76.313079023615
+    if basis == 'cfour-qz2p':
+        scftot = -76.062748460117
+        mp2corl = -0.245151837406
+        mp2tot = -76.307900312177
+        ccsdcorl = -0.250330548844
+        ccsdtot = -76.313079023615
+    elif basis == 'aug-cc-pvdz':
+        scftot = -76.0413815332
+        mp2corl = -0.2194081478
+        mp2tot = -76.2607896810
+        ccsdcorl = -0.2271733460
+        ccsdtot = -76.2685548793
 
     atol = 1.e-6
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + ' SCF', atol=atol)
-    if not (mtd == 'nwc-ccsd' and opts.get('qc_module', 'nein').lower() == 'tce'):
+    if not (method == 'nwc-ccsd' and keywords.get('qc_module', 'nein').lower() == 'tce'):
         assert compare_values(mp2corl, qcdb.variable('mp2 correlation energy'), tnm() + ' MP2 corl', atol=atol)
         assert compare_values(mp2tot, qcdb.variable('mp2 total energy'), tnm() + ' MP2', atol=atol)
     assert compare_values(ccsdcorl, qcdb.variable('ccsd correlation energy'), tnm() + ' CCSD corl', atol=atol)
     assert compare_values(ccsdtot, qcdb.variable('ccsd total energy'), tnm() + ' CCSD', atol=atol)
 
 
-@pytest.mark.parametrize('mtd,opts,errmsg', [
+@pytest.mark.parametrize('method,keywords,errmsg', [
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_scf__uhf': True}, 'ccsd: nopen is not zero', marks=using_nwchem),
     pytest.param('gms-ccsd', {'basis': 'cfour-qz2p', 'gamess_contrl__scftyp': 'uhf', 'gamess_ccinp__ncore': 0}, 'CCTYP IS PROGRAMMED ONLY FOR SCFTYP=RHF OR ROHF', marks=using_gamess),
 ])
-def test_sp_ccsd_uhf_full_error(mtd, opts, nh2, errmsg):
+def test_sp_ccsd_uhf_full_error(method, keywords, nh2, errmsg):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
     with pytest.raises(qcng.exceptions.InputError) as e:
-        qcdb.energy(mtd, molecule=nh2)
+        qcdb.energy(method, molecule=nh2)
 
     assert errmsg in str(e.value)
 
 
-@pytest.mark.parametrize('mtd,opts', [
+@pytest.mark.parametrize('method,keywords', [
     pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_REFerence': 'UHF', 'cfour_occupation': [[3,1,1,0],[3,0,1,0]], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
     pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p', 'cfour_reference': 'uhf'}, marks=using_cfour),
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'qc_module': 'tce', 'nwchem_scf__uhf': True}, marks=using_nwchem),
     pytest.param('p4-ccsd', {'basis': 'cfour-qz2p', 'reference': 'uhf'}, marks=using_psi4),
 ])
-def test_sp_ccsd_uhf_full(mtd, opts, nh2):
+def test_sp_ccsd_uhf_full(method, keywords, nh2):
     """cfour/sp-uhf-ccsd/input.dat
     #! single-point CCSD/qz2p on NH2
 
     """
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
-    e = qcdb.energy(mtd, molecule=nh2)
+    e = qcdb.energy(method, molecule=nh2)
 
     scftot = -55.5893469688
     mp2tot = -55.784877360093
@@ -133,41 +158,41 @@ def test_sp_ccsd_uhf_full(mtd, opts, nh2):
 
     atol = 1.e-6
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + ' SCF', atol=atol)
-    if not (mtd == 'nwc-ccsd' and opts.get('qc_module', 'nein').lower() == 'tce'):
+    if not (method == 'nwc-ccsd' and keywords.get('qc_module', 'nein').lower() == 'tce'):
         assert compare_values(mp2tot, qcdb.variable('mp2 total energy'), tnm() + ' MP2', atol=atol)
     assert compare_values(ccsdcorl, qcdb.variable('ccsd correlation energy'), tnm() + ' CCSD', atol=atol)
     assert compare_values(ccsdcorl+scftot, e, atol=atol)
 
 
-@pytest.mark.parametrize('mtd,opts,errmsg', [
+@pytest.mark.parametrize('method,keywords,errmsg', [
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_ccsd__freeze': 1, 'nwchem_scf__uhf': True}, 'ccsd: nopen is not zero', marks=using_nwchem),
     pytest.param('gms-ccsd', {'basis': 'cfour-qz2p', 'gamess_contrl__scftyp': 'uhf'}, 'CCTYP IS PROGRAMMED ONLY FOR SCFTYP=RHF OR ROHF', marks=using_gamess),
 ])
-def test_sp_ccsd_uhf_fc_error(mtd, opts, nh2, errmsg):
+def test_sp_ccsd_uhf_fc_error(method, keywords, nh2, errmsg):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
     with pytest.raises(qcng.exceptions.InputError) as e:
-        qcdb.energy(mtd, molecule=nh2)
+        qcdb.energy(method, molecule=nh2)
 
     assert errmsg in str(e.value)
 
 
-@pytest.mark.parametrize('mtd,opts', [
+@pytest.mark.parametrize('method,keywords', [
     pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_dropmo': [1], 'cfour_REFerence': 'UHF', 'cfour_occupation': [[3,1,1,0],[3,0,1,0]], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
     pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p', 'cfour_dropmo': 1, 'cfour_reference': 'uhf'}, marks=using_cfour),
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_tce__freeze': 1, 'qc_module': 'tce', 'nwchem_scf__uhf': True}, marks=using_nwchem),
     pytest.param('p4-ccsd', {'basis': 'cfour-qz2p', 'psi4_freeze_core': True, 'reference': 'uhf'}, marks=using_psi4),
 ])
-def test_sp_ccsd_uhf_fc(mtd, opts, nh2):
+def test_sp_ccsd_uhf_fc(method, keywords, nh2):
     """cfour/sp-uhf-ccsd/input.dat
     #! single-point CCSD/qz2p on NH2
 
     """
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
-    e = qcdb.energy(mtd, molecule=nh2)
+    e = qcdb.energy(method, molecule=nh2)
 
     scftot = -55.5893469688
     mp2corl = -0.171184123712
@@ -177,45 +202,58 @@ def test_sp_ccsd_uhf_fc(mtd, opts, nh2):
 
     atol = 1.e-6
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + ' SCF', atol=atol)
-    if not (mtd == 'nwc-ccsd' and opts.get('qc_module', 'nein').lower() == 'tce'):
+    if not (method== 'nwc-ccsd' and keywords.get('qc_module', 'nein').lower() == 'tce'):
         assert compare_values(mp2tot, qcdb.variable('mp2 total energy'), tnm() + ' MP2', atol=atol)
     assert compare_values(ccsdcorl, qcdb.variable('ccsd correlation energy'), tnm() + ' CCSD', atol=atol)
     assert compare_values(ccsdcorl+scftot, e, atol=atol)
 
 
-@pytest.mark.parametrize('mtd,opts,errmsg', [
+@pytest.mark.parametrize('method,keywords,errmsg', [
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_scf__rohf': True}, 'ccsd: nopen is not zero', marks=using_nwchem),
 ])
-def test_sp_ccsd_rohf_full_error(mtd, opts, nh2, errmsg):
+def test_sp_ccsd_rohf_full_error(method, keywords, nh2, errmsg):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
     with pytest.raises(qcng.exceptions.InputError) as e:
-        qcdb.energy(mtd, molecule=nh2)
+        qcdb.energy(method, molecule=nh2)
 
     assert errmsg in str(e.value)
 
 
-@pytest.mark.parametrize('mtd,opts', [
-    pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_REFerence': 'roHF', 'cfour_occupation': [[3,1,1,0],[3,0,1,0]], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
-    pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p', 'cfour_reference': 'rohf'}, marks=using_cfour),
-    pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'qc_module': 'tce', 'nwchem_scf__rohf': True}, marks=using_nwchem),
-    pytest.param('p4-ccsd', {'basis': 'cfour-qz2p', 'reference': 'rohf'}, marks=using_psi4),
-    pytest.param('gms-ccsd', {'basis': 'cfour-qz2p', 'gamess_contrl__scftyp': 'rohf', 'gamess_ccinp__ncore': 0}, marks=using_gamess),
+@pytest.mark.parametrize('basis', [
+    'cfour-qz2p',
+    'aug-cc-pvdz',
 ])
-def test_sp_ccsd_rohf_full(mtd, opts, nh2):
+@pytest.mark.parametrize('method,keywords', [
+    pytest.param('c4-ccsd', {'cfour_REFerence': 'roHF', 'cfour_occupation': [[3,1,1,0],[3,0,1,0]], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
+    #pytest.param('c4-ccsd', {'cfour_reference': 'rohf'}, marks=using_cfour),
+    #pytest.param('nwc-ccsd', {'qc_module': 'tce', 'nwchem_scf__rohf': True}, marks=using_nwchem),
+    #pytest.param('p4-ccsd', {'reference': 'rohf'}, marks=using_psi4),
+    #pytest.param('gms-ccsd', {'gamess_contrl__scftyp': 'rohf', 'gamess_ccinp__ncore': 0}, marks=using_gamess),
+])
+def test_sp_ccsd_rohf_full(method, basis, keywords, nh2):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    keywords['basis'] = basis
+    qcdb.set_options(keywords)
 #        'cfour_PRINT': 2
 
-    e = qcdb.energy(mtd, molecule=nh2)
-    scftot = -55.5847372601
-    ssccsdcorl = -0.0398915
-    osccsdcorl = -0.1779580
-    #osccsdcorl = -0.1745752
-    #ssccsdcorl = -0.0432743
-    ccsdcorl = -0.217849506326
-    ccsdtot = -55.802586766392
+    e = qcdb.energy(method, molecule=nh2)
+
+    if basis == 'cfour-qz2p':
+        scftot = -55.5847372601
+        ssccsdcorl = -0.0398915
+        osccsdcorl = -0.1779580
+        #osccsdcorl = -0.1745752
+        #ssccsdcorl = -0.0432743
+        ccsdcorl = -0.217849506326
+        ccsdtot = -55.802586766392
+    elif basis == 'aug-cc-pvdz':
+        scftot = -55.570724348574
+        ssccsdcorl = -0.0339827
+        osccsdcorl = -0.1442533
+        ccsdcorl = -0.178236032911
+        ccsdtot = -55.748960381485
 
     atol = 1.e-6
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + 'SCF', atol=atol)
@@ -224,7 +262,7 @@ def test_sp_ccsd_rohf_full(mtd, opts, nh2):
     # not printed assert compare_values(ssmp2corl, qcdb.variable('mp2 same-spin correlation energy'), tnm() + ' MP2 SS corl', atol=atol)
     # not printed assert compare_values(mp2corl, qcdb.variable('mp2 correlation energy'), tnm() + ' MP2 corl', atol=atol)
     # not printed assert compare_values(mp2tot, qcdb.variable('mp2 total energy'), tnm() + ' MP2', atol=atol)
-    if not (mtd in ['gms-ccsd', 'nwc-ccsd']):
+    if not (method in ['gms-ccsd', 'nwc-ccsd']):
 # cfour isn't splitting out the singles from OS. and psi4 isn't incl the singles in either so SS + OS != corl
 # and maybe singles moved from SS to OS in Cfour btwn 2010 and 2014 versions (change in ref)
 #        assert compare_values(osccsdcorl, qcdb.variable('ccsd opposite-spin correlation energy'), tnm() + ' CCSD OS corl', atol=atol)
@@ -235,32 +273,32 @@ def test_sp_ccsd_rohf_full(mtd, opts, nh2):
     assert compare_values(ccsdtot, qcdb.variable('current energy'), tnm() + ' Current', atol=atol)
 
 
-@pytest.mark.parametrize('mtd,opts,errmsg', [
+@pytest.mark.parametrize('method,keywords,errmsg', [
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_ccsd__freeze': 1, 'nwchem_scf__rohf': True}, 'ccsd: nopen is not zero', marks=using_nwchem), #, pytest.mark.xfail(True, reason='NWChem has no hand-coded ROHF CC. Sensible error msg.', run=True)]),
 ])
-def test_sp_ccsd_rohf_fc_error(mtd, opts, nh2, errmsg):
+def test_sp_ccsd_rohf_fc_error(method, keywords, nh2, errmsg):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
     with pytest.raises(qcng.exceptions.InputError) as e:
-        qcdb.energy(mtd, molecule=nh2)
+        qcdb.energy(method, molecule=nh2)
 
     assert errmsg in str(e.value)
     # check input file, too?
 
 
-@pytest.mark.parametrize('mtd,opts', [
+@pytest.mark.parametrize('method,keywords', [
     pytest.param('c4-ccsd', {'cfour_BASIS': 'qz2p', 'cfour_dropmo': [1], 'cfour_print': 2, 'cfour_REFerence': 'roHF', 'cfour_occupation': [[3,1,1,0],[3,0,1,0]], 'cfour_SCF_CONV': 12, 'cfour_CC_CONV': 12}, marks=using_cfour),
     pytest.param('c4-ccsd', {'BASIS': 'cfour-qz2p', 'cfour_dropmo': 1, 'cfour_reference': 'rohf'}, marks=using_cfour),
     pytest.param('nwc-ccsd', {'basis': 'cfour-qz2p', 'nwchem_tce__freeze': 1, 'qc_module': 'tce', 'nwchem_scf__rohf': True}, marks=using_nwchem),
     pytest.param('p4-ccsd', {'basis': 'cfour-qz2p', 'psi4_e_convergence': 8, 'psi4_r_convergence': 7, 'psi4_freeze_core': True, 'reference': 'rohf'}, marks=using_psi4),
     pytest.param('gms-ccsd', {'basis': 'cfour-qz2p', 'gamess_contrl__scftyp': 'rohf', 'gamess_ccinp__iconv': 9, 'gamess_scf__conv': 9}, marks=using_gamess),
 ])
-def test_sp_ccsd_rohf_fc(mtd, opts, nh2):
+def test_sp_ccsd_rohf_fc(method, keywords, nh2):
     nh2 = qcdb.set_molecule(nh2)
-    qcdb.set_options(opts)
+    qcdb.set_options(keywords)
 
-    e = qcdb.energy(mtd, molecule=nh2)
+    e = qcdb.energy(method, molecule=nh2)
 
     # from Cfour
     scftot = -55.5847372601
@@ -284,7 +322,7 @@ def test_sp_ccsd_rohf_fc(mtd, opts, nh2):
     weakatol = 2.e-5
 
     assert compare_values(scftot, qcdb.variable('scf total energy'), tnm() + 'SCF', atol=1.e-6)
-    if not (mtd in ['gms-ccsd', 'nwc-ccsd']):
+    if not (method in ['gms-ccsd', 'nwc-ccsd']):
 #        assert compare_values(osccsdcorl, qcdb.variable('ccsd opposite-spin correlation energy'), tnm() + ' CCSD OS corl', atol=1.e-6)
         assert compare_values(ssccsdcorl, qcdb.variable('ccsd same-spin correlation energy'), tnm() + ' CCSD SS corl', atol=weakatol)
     assert compare_values(ccsdcorl, qcdb.variable('ccsd correlation energy'), tnm() + ' CCSD corl', atol=weakatol)


### PR DESCRIPTION
* some options and molecule formatting moved to qcel and qcng
* cleared out some of the old nwchem options fns (not any of those by Jiyoung that may still be useful)